### PR TITLE
Add Issue linker workflow (CSC-5)

### DIFF
--- a/.github/workflows/issueLinker-workflow.yml
+++ b/.github/workflows/issueLinker-workflow.yml
@@ -1,0 +1,19 @@
+name: Attach Issue Link
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tzkhan/pr-update-action@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        head-branch-regex: '(?<=-)(.*?)(?=-)'
+        body-template: |
+          Fixes #%headbranch%
+        body-update-action: 'suffix'
+        body-uppercase-head-match: false
+        lowercase-branch: false

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ https://www.nuget.org/packages/Common.Security.Cryptography#readme-body-tab
 # Contributions
 
 Cryptography and data security are important for network and other data management. Feel free to create issues and updates to the library to help it grow and gain access to further security keys.
+
+When creating a branch, please create the branch name using the following format:
+`csc-[issue number]-[name]`
+
+There is a workflow that will automatically attach issues to a PR given the format above.
+`CSC` is an abbreviation for the library
+`Issue number` is the issue that is being addressed by the PR
+`Name` is the logical branch name for the work being submitted. While not required, words may be split using `-`. i.e. `csc-5-a-new-branch-fixing-a-terrible-bug` 
+
+When submitting a PR, please include the issue number in the commit title so that it is readable at a glance, i.e. `Fixing a bug (CSC-5)`


### PR DESCRIPTION
Motivation
----
The current repository does not auto link issues to associated PRs once they are submitted and individuals must remember to link them manually

Modifications
----
* Added github workflow for linking issues based on a provided branch name format
* Updated README to reflect new branch naming format

Result
----
There is a workflow that will auto link issues to PRs

Fixes #5